### PR TITLE
Drop and create tables on database upgrade

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.31'
+version = '2.0.36'
 
 android {
     compileSdkVersion 25
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 38
+        versionCode 43
         versionName version
         vectorDrawables.useSupportLibrary = true
     }

--- a/backbone/src/main/java/org/researchstack/backbone/storage/database/sqlite/SqlCipherDatabaseHelper.java
+++ b/backbone/src/main/java/org/researchstack/backbone/storage/database/sqlite/SqlCipherDatabaseHelper.java
@@ -60,7 +60,17 @@ public class SqlCipherDatabaseHelper extends SqueakyOpenHelper implements AppDat
 
     @Override
     public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i1) {
-        // handle future db upgrades here
+        try {
+            TableUtils.dropTables(new SQLiteDatabaseImpl(sqLiteDatabase),
+                    true,
+                    TaskRecord.class,
+                    StepRecord.class);
+            TableUtils.createTables(new SQLiteDatabaseImpl(sqLiteDatabase),
+                    TaskRecord.class,
+                    StepRecord.class);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     //*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-

--- a/backbone/src/main/java/org/researchstack/backbone/storage/database/staged/StagedDatabaseHelper.java
+++ b/backbone/src/main/java/org/researchstack/backbone/storage/database/staged/StagedDatabaseHelper.java
@@ -37,8 +37,25 @@ public class StagedDatabaseHelper extends SqlCipherDatabaseHelper {
 
     @Override
     public void onCreate(SQLiteDatabase sqLiteDatabase) {
+        super.onCreate(sqLiteDatabase);
         try {
-            super.onCreate(sqLiteDatabase);
+            TableUtils.createTables(new SQLiteDatabaseImpl(sqLiteDatabase),
+                    StagedActivityRecord.class,
+                    StagedEventRecord.class);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i1) {
+        super.onUpgrade(sqLiteDatabase, i, i1);
+        try {
+            TableUtils.dropTables(new SQLiteDatabaseImpl(sqLiteDatabase),
+                    true,
+                    StagedActivityRecord.class,
+                    StagedEventRecord.class);
+
             TableUtils.createTables(new SQLiteDatabaseImpl(sqLiteDatabase),
                     StagedActivityRecord.class,
                     StagedEventRecord.class);

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.31'
+version = '2.0.36'
 
 android {
     compileSdkVersion 25
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 38
+        versionCode 43
         versionName version
     }
     buildTypes {


### PR DESCRIPTION
This is the first attempt to support changes on the database models.
This very basic feature just drops all tables (and all data) and recreate the new table models.

This is enough for Alpha testing, and will be improved when necessary during beta or release.