### PR TITLE
Feature/add month year question step

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.84'
+version = '2.0.85'
 
 android {
     compileSdkVersion 25
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 91
+        versionCode 92
         versionName version
         vectorDrawables.useSupportLibrary = true
     }

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.79'
+version = '2.0.81'
 
 android {
     compileSdkVersion 25
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 86
+        versionCode 88
         versionName version
         vectorDrawables.useSupportLibrary = true
     }

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.83'
+version = '2.0.84'
 
 android {
     compileSdkVersion 25
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 90
+        versionCode 91
         versionName version
         vectorDrawables.useSupportLibrary = true
     }

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.81'
+version = '2.0.83'
 
 android {
     compileSdkVersion 25
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 88
+        versionCode 90
         versionName version
         vectorDrawables.useSupportLibrary = true
     }

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.71'
+version = '2.0.79'
 
 android {
     compileSdkVersion 25
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 78
+        versionCode 86
         versionName version
         vectorDrawables.useSupportLibrary = true
     }

--- a/backbone/src/main/java/org/researchstack/backbone/answerformat/AnswerFormat.java
+++ b/backbone/src/main/java/org/researchstack/backbone/answerformat/AnswerFormat.java
@@ -55,6 +55,7 @@ public abstract class AnswerFormat implements Serializable {
         Eligibility(NotImplementedStepBody.class),
         Text(TextQuestionBody.class),
         TimeOfDay(DateQuestionBody.class),
+        MonthYear(DateQuestionBody.class),
         DateAndTime(DateQuestionBody.class),
         Date(DateQuestionBody.class),
         TimeInterval(NotImplementedStepBody.class),
@@ -98,7 +99,8 @@ public abstract class AnswerFormat implements Serializable {
     public enum DateAnswerStyle {
         DateAndTime,
         Date,
-        TimeOfDay
+        TimeOfDay,
+        MonthYear
     }
 
     /**

--- a/backbone/src/main/java/org/researchstack/backbone/answerformat/DateAnswerFormat.java
+++ b/backbone/src/main/java/org/researchstack/backbone/answerformat/DateAnswerFormat.java
@@ -92,6 +92,7 @@ public class DateAnswerFormat extends AnswerFormat
         if(style == DateAnswerStyle.Date) return Type.Date;
         if(style == DateAnswerStyle.DateAndTime) return Type.DateAndTime;
         if(style == DateAnswerStyle.TimeOfDay) return Type.TimeOfDay;
+        if(style == DateAnswerStyle.MonthYear) return Type.MonthYear;
 
         return Type.None;
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DateQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DateQuestionBody.java
@@ -72,7 +72,7 @@ public class DateQuestionBody implements StepBody {
             } else if (this.result.getResult() instanceof String) {
                 try {
                     SimpleDateFormat parseFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-                    Date parsedResult = parseFormat.parse((String)this.result.getResult());
+                    Date parsedResult = parseFormat.parse((String) this.result.getResult());
                     calendar.setTime(parsedResult);
                     savedTimeInMillis = calendar.getTimeInMillis();
                 } catch (Exception e) {

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DateQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DateQuestionBody.java
@@ -23,6 +23,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 public class DateQuestionBody implements StepBody {
     //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -55,6 +56,8 @@ public class DateQuestionBody implements StepBody {
             this.dateformatter = FormatHelper.getFormat(FormatHelper.NONE, DateFormat.MEDIUM);
         } else if (format.getStyle() == AnswerFormat.DateAnswerStyle.MonthYear) {
             this.dateformatter = new SimpleDateFormat("MM/yyyy");
+            this.dateformatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+            this.calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         }
 
 
@@ -68,7 +71,7 @@ public class DateQuestionBody implements StepBody {
                 savedTimeInMillis = (Long) this.result.getResult();
             } else if (this.result.getResult() instanceof String) {
                 try {
-                    SimpleDateFormat parseFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+                    SimpleDateFormat parseFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
                     Date parsedResult = parseFormat.parse((String)this.result.getResult());
                     calendar.setTime(parsedResult);
                     savedTimeInMillis = calendar.getTimeInMillis();

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/FormStepLayout.java
@@ -2,6 +2,7 @@ package org.researchstack.backbone.ui.step.layout;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Handler;
 import android.os.Parcelable;
 import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
@@ -11,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -286,8 +288,19 @@ public class FormStepLayout extends FixedSubmitBarLayout implements StepLayout {
         boolean isAnswerValid = isAnswerValid(true);
         if (isAnswerValid)
         {
-            updateAllQuestionSteps(false);
-            callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, formStep, stepResult);
+            // WORKAROUND : Hide softkeyboard before transaction
+            InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (imm != null && container != null) {
+                imm.hideSoftInputFromWindow(container.getWindowToken(), 0);
+            }
+            final Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    updateAllQuestionSteps(false);
+                    callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, formStep, stepResult);
+                }
+            }, 100);
         }
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/MonthYearPickerDialog.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/MonthYearPickerDialog.java
@@ -33,21 +33,21 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
     private int mMinMonth = 1;
 
     private MonthYearPickerDialog.OnDateSetListener mDateSetListener;
-    private View dialogView;
+    private View mDialogView;
 
     public MonthYearPickerDialog(Context context) {
         super(context);
 
         final Context themeContext = getContext();
         final LayoutInflater inflater = LayoutInflater.from(themeContext);
-        dialogView = inflater.inflate(R.layout.rsb_layout_month_year_picker, null);
-        setView(dialogView);
+        mDialogView = inflater.inflate(R.layout.rsb_layout_month_year_picker, null);
+        setView(mDialogView);
 
         setButton(BUTTON_POSITIVE, themeContext.getString(R.string.rsb_ok), this);
         setButton(BUTTON_NEGATIVE, themeContext.getString(R.string.rsb_cancel), this);
 
-        final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
-        final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+        final NumberPicker monthPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_month);
+        final NumberPicker yearPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_year);
 
         Calendar cal = Calendar.getInstance();
         mMaxYear = cal.get(Calendar.YEAR) + 100;
@@ -104,9 +104,9 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
         cal.setTime(mDateValue);
         mYear = cal.get(Calendar.YEAR);
         mMonth = cal.get(Calendar.MONTH) + 1;
-        if (dialogView != null) {
-            final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
-            final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+        if (mDialogView != null) {
+            final NumberPicker monthPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_month);
+            final NumberPicker yearPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_year);
             yearPicker.setValue(mYear);
             monthPicker.setValue(mMonth);
         }
@@ -124,9 +124,9 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
             mMaxMonth = 12;
         }
 
-        if (dialogView != null) {
-            final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
-            final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+        if (mDialogView != null) {
+            final NumberPicker monthPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_month);
+            final NumberPicker yearPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_year);
             yearPicker.setMaxValue(mMaxYear);
             monthPicker.setMaxValue(mMaxMonth);
         }
@@ -144,9 +144,9 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
             mMinYear = 1900;
             mMinMonth = 1;
         }
-        if (dialogView != null) {
-            final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
-            final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+        if (mDialogView != null) {
+            final NumberPicker monthPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_month);
+            final NumberPicker yearPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_year);
             yearPicker.setMinValue(mMinYear);
             monthPicker.setMinValue(mMinMonth);
         }
@@ -157,7 +157,7 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
         setCurrentDate(currentDate);
         setMinDate(minDate);
         setMaxDate(maxDate);
-        if (dialogView != null && mYear > 0) {
+        if (mDialogView != null && mYear > 0) {
             updateMonthPickerLimits(mYear);
         }
     }
@@ -203,7 +203,7 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
     }
 
     private void updateMonthPickerLimits(int year) {
-        final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
+        final NumberPicker monthPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_month);
         monthPicker.setMinValue(1);
         monthPicker.setMaxValue(12);
         if (year == mMaxYear && year == mMinYear) {
@@ -223,14 +223,14 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
         switch (which) {
             case BUTTON_POSITIVE:
                 if (mDateSetListener != null) {
-                    final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
-                    final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+                    final NumberPicker monthPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_month);
+                    final NumberPicker yearPicker = (NumberPicker) mDialogView.findViewById(R.id.picker_year);
 
                     mYear = yearPicker.getValue();
                     mMonth = monthPicker.getValue();
 
-                    dialogView.clearFocus();
-                    mDateSetListener.onDateSet(dialogView, mYear, mMonth - 1, 1);
+                    mDialogView.clearFocus();
+                    mDateSetListener.onDateSet(mDialogView, mYear, mMonth - 1, 1);
                 }
                 break;
             case BUTTON_NEGATIVE:

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/MonthYearPickerDialog.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/MonthYearPickerDialog.java
@@ -1,0 +1,258 @@
+package org.researchstack.backbone.ui.views;
+
+import android.app.AlertDialog;
+import android.app.DatePickerDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.DatePicker;
+import android.widget.NumberPicker;
+
+import org.researchstack.backbone.R;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * Created by spiria on 22/3/18.
+ */
+
+public class MonthYearPickerDialog extends AlertDialog implements DialogInterface.OnClickListener, DatePickerDialog.OnDateSetListener {
+
+    private Date mDateValue;
+    private int mYear = -1;
+    private int mMonth = -1;
+
+    private Date mMaxDate = null;
+    private int mMaxYear = -1;
+    private int mMaxMonth = 12;
+
+    private Date mMinDate = null;
+    private int mMinYear = 1900;
+    private int mMinMonth = 1;
+
+    private MonthYearPickerDialog.OnDateSetListener mDateSetListener;
+    private View dialogView;
+
+    public MonthYearPickerDialog(Context context) {
+        super(context);
+
+        final Context themeContext = getContext();
+        final LayoutInflater inflater = LayoutInflater.from(themeContext);
+        dialogView = inflater.inflate(R.layout.rsb_layout_month_year_picker, null);
+        setView(dialogView);
+
+        setButton(BUTTON_POSITIVE, themeContext.getString(R.string.rsb_ok), this);
+        setButton(BUTTON_NEGATIVE, themeContext.getString(R.string.rsb_cancel), this);
+
+        final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
+        final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+
+        Calendar cal = Calendar.getInstance();
+        mMaxYear = cal.get(Calendar.YEAR) + 100;
+        if (mMaxDate != null) {
+            cal.setTime(mMaxDate);
+            mMaxYear = cal.get(Calendar.YEAR);
+            mMaxMonth = cal.get(Calendar.MONTH) + 1;
+        }
+        yearPicker.setMaxValue(mMaxYear);
+        monthPicker.setMaxValue(mMaxMonth);
+
+        if (mMinDate != null) {
+            cal.setTime(mMinDate);
+            mMinYear = cal.get(Calendar.YEAR);
+            mMinMonth = cal.get(Calendar.MONTH) + 1;
+        }
+        yearPicker.setMinValue(mMinYear);
+
+        yearPicker.setOnValueChangedListener(new NumberPicker.OnValueChangeListener() {
+            @Override
+            public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
+                updateMonthPickerLimits(newVal);
+            }
+        });
+
+        if (mYear > 0) {
+            yearPicker.setValue(mYear);
+        } else if (mMaxDate != null){
+            yearPicker.setValue(mMaxYear);
+        } else {
+            Calendar c = Calendar.getInstance();
+            yearPicker.setValue(c.get(Calendar.YEAR));
+        }
+
+        updateMonthPickerLimits(yearPicker.getValue());
+
+        if (mMonth > 0) {
+            monthPicker.setValue(mMonth);
+        } else if (mMaxDate != null){
+            monthPicker.setValue(mMaxMonth);
+        } else {
+            Calendar c = Calendar.getInstance();
+            monthPicker.setValue(c.get(Calendar.MONTH) + 1);
+        }
+    }
+
+    public void setOnDateSetListener(MonthYearPickerDialog.OnDateSetListener listener) {
+        mDateSetListener = listener;
+    }
+
+    public void setCurrentDate(Date currentDate) {
+        mDateValue = currentDate;
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(mDateValue);
+        mYear = cal.get(Calendar.YEAR);
+        mMonth = cal.get(Calendar.MONTH) + 1;
+        if (dialogView != null) {
+            final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
+            final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+            yearPicker.setValue(mYear);
+            monthPicker.setValue(mMonth);
+        }
+    }
+
+    public void setMaxDate(Date maxDate) {
+        this.mMaxDate = maxDate;
+        Calendar cal = Calendar.getInstance();
+        if (mMaxDate != null) {
+            cal.setTime(mMaxDate);
+            mMaxYear = cal.get(Calendar.YEAR);
+            mMaxMonth = cal.get(Calendar.MONTH) + 1;
+        } else {
+            mMaxYear = cal.get(Calendar.YEAR) + 100;
+            mMaxMonth = 12;
+        }
+
+        if (dialogView != null) {
+            final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
+            final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+            yearPicker.setMaxValue(mMaxYear);
+            monthPicker.setMaxValue(mMaxMonth);
+        }
+        clearDateIfInvalid();
+    }
+
+    public void setMinDate(Date minDate) {
+        this.mMinDate = minDate;
+        Calendar cal = Calendar.getInstance();
+        if (mMinDate != null) {
+            cal.setTime(mMinDate);
+            mMinYear = cal.get(Calendar.YEAR);
+            mMinMonth = cal.get(Calendar.MONTH) + 1;
+        } else {
+            mMinYear = 1900;
+            mMinMonth = 1;
+        }
+        if (dialogView != null) {
+            final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
+            final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+            yearPicker.setMinValue(mMinYear);
+            monthPicker.setMinValue(mMinMonth);
+        }
+        clearDateIfInvalid();
+    }
+
+    public void setPickerState(Date minDate, Date maxDate, Date currentDate) {
+        setCurrentDate(currentDate);
+        setMinDate(minDate);
+        setMaxDate(maxDate);
+    }
+
+    public void clearDate() {
+        mDateValue = null;
+        mMonth = -1;
+        mYear = -1;
+    }
+
+    public void clearDateIfInvalid() {
+        if (mMinDate != null && mDateValue != null) {
+            if (compareDate(mDateValue, mMinDate) < 0) {
+                clearDate();
+            }
+        }
+        if (mMaxDate != null && mDateValue != null) {
+            if (compareDate(mDateValue, mMaxDate) > 0) {
+                clearDate();
+            }
+        }
+    }
+
+    private int compareDate(Date date1, Date date2) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date1);
+        Integer month1 = calendar.get(Calendar.MONTH);
+        Integer year1 = calendar.get(Calendar.YEAR);
+
+        calendar.setTime(date2);
+        Integer month2 = calendar.get(Calendar.MONTH);
+        Integer year2 = calendar.get(Calendar.YEAR);
+
+        if (year1.equals(year2)) {
+            if (month1.equals(month2)) {
+                return 0;
+            } else {
+                return month1.compareTo(month2);
+            }
+        } else {
+            return year1.compareTo(year2);
+        }
+    }
+
+    private void updateMonthPickerLimits(int year) {
+        final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
+        if (year == mMinYear) {
+            monthPicker.setMinValue(mMinMonth);
+            monthPicker.setMaxValue(12);
+        } else if (year == mMaxYear) {
+            monthPicker.setMinValue(1);
+            monthPicker.setMaxValue(mMaxMonth);
+        } else {
+            monthPicker.setMinValue(1);
+            monthPicker.setMaxValue(12);
+        }
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        switch (which) {
+            case BUTTON_POSITIVE:
+                if (mDateSetListener != null) {
+                    final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
+                    final NumberPicker yearPicker = (NumberPicker) dialogView.findViewById(R.id.picker_year);
+
+                    mYear = yearPicker.getValue();
+                    mMonth = monthPicker.getValue();
+
+                    dialogView.clearFocus();
+                    mDateSetListener.onDateSet(dialogView, mYear, mMonth - 1, 1);
+                }
+                break;
+            case BUTTON_NEGATIVE:
+                cancel();
+                break;
+        }
+    }
+
+    @Override
+    public void onDateSet(DatePicker view, int year, int month, int dayOfMonth) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month, dayOfMonth);
+
+        mDateValue = cal.getTime();
+        mYear = cal.get(Calendar.YEAR);
+        mMonth = cal.get(Calendar.MONTH) + 1;
+    }
+
+    public interface OnDateSetListener {
+        /**
+         * @param view the picker associated with the dialog
+         * @param year the selected year
+         * @param month the selected month (0-11 for compatibility with
+         *              {@link Calendar#MONTH})
+         * @param dayOfMonth th selected day of the month (1-31, depending on
+         *                   month)
+         */
+        void onDateSet(View view, int year, int month, int dayOfMonth);
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/ui/views/MonthYearPickerDialog.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/views/MonthYearPickerDialog.java
@@ -157,6 +157,9 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
         setCurrentDate(currentDate);
         setMinDate(minDate);
         setMaxDate(maxDate);
+        if (dialogView != null && mYear > 0) {
+            updateMonthPickerLimits(mYear);
+        }
     }
 
     public void clearDate() {
@@ -201,14 +204,16 @@ public class MonthYearPickerDialog extends AlertDialog implements DialogInterfac
 
     private void updateMonthPickerLimits(int year) {
         final NumberPicker monthPicker = (NumberPicker) dialogView.findViewById(R.id.picker_month);
-        if (year == mMinYear) {
+        monthPicker.setMinValue(1);
+        monthPicker.setMaxValue(12);
+        if (year == mMaxYear && year == mMinYear) {
             monthPicker.setMinValue(mMinMonth);
-            monthPicker.setMaxValue(12);
+            monthPicker.setMaxValue(mMaxMonth);
         } else if (year == mMaxYear) {
             monthPicker.setMinValue(1);
             monthPicker.setMaxValue(mMaxMonth);
-        } else {
-            monthPicker.setMinValue(1);
+        } else if (year == mMinYear) {
+            monthPicker.setMinValue(mMinMonth);
             monthPicker.setMaxValue(12);
         }
     }

--- a/backbone/src/main/res/layout/rsb_layout_month_year_picker.xml
+++ b/backbone/src/main/res/layout/rsb_layout_month_year_picker.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:orientation="horizontal">
+
+        <NumberPicker
+            android:id="@+id/picker_month"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/medium_spacing"
+            android:layout_marginRight="@dimen/medium_spacing">
+
+        </NumberPicker>
+
+        <NumberPicker
+            android:id="@+id/picker_year"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+        </NumberPicker>
+
+    </LinearLayout>
+</LinearLayout>

--- a/backbone/src/main/res/values/dimens.xml
+++ b/backbone/src/main/res/values/dimens.xml
@@ -40,5 +40,6 @@
     <dimen name="rsb_step_layout_countdown_size">@dimen/rsb_step_layout_image_height</dimen>
 
     <dimen name="rsb_step_layout_tapping_interval_button_size">100dp</dimen>
+    <dimen name="medium_spacing">16dp</dimen>
 
 </resources>

--- a/backbone/src/main/res/values/strings.xml
+++ b/backbone/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="rsb_hint_step_body_date">Enter a date</string>
     <string name="rsb_hint_step_body_time">Enter a time</string>
     <string name="rsb_hint_step_body_datetime">Enter a date and a time</string>
+    <string name="rsb_hint_step_body_monthyear">Enter a Month/Year</string>
     <string name="rsb_hint_step_body_text">Answer</string>
 
     <!-- Graphing -->

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.83'
+version = '2.0.84'
 
 android {
     compileSdkVersion 25
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 90
+        versionCode 91
         versionName version
     }
     buildTypes {

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.84'
+version = '2.0.85'
 
 android {
     compileSdkVersion 25
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 91
+        versionCode 92
         versionName version
     }
     buildTypes {

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.81'
+version = '2.0.83'
 
 android {
     compileSdkVersion 25
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 88
+        versionCode 90
         versionName version
     }
     buildTypes {

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.79'
+version = '2.0.81'
 
 android {
     compileSdkVersion 25
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 86
+        versionCode 88
         versionName version
     }
     buildTypes {

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.71'
+version = '2.0.79'
 
 android {
     compileSdkVersion 25
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 78
+        versionCode 86
         versionName version
     }
     buildTypes {


### PR DESCRIPTION
### Description

Update Date Question to support `MM/yyyy` format 
A new DatePickerDialog was added to support two spinners selection only for Month and Year since the Android calendar doesn't support that.
Fix issue with consent and soft keyboard on Consent

### Acceptance Criterial

- [ ] Open app, take Disease History survey, check that step 3 is a MonthYear Date question
- [ ] Save resultas after select a MontYear date, retake the survey and make sure the selected value is shown correctly
- [ ] Start Registration process, check that the keyboard is closed after the sign information is entered and the user press "Next"
