### PR TITLE
Support HTML on Step's question (title) and Consent's summary

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.85'
+version = '2.0.86'
 
 android {
     compileSdkVersion 25
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 92
+        versionCode 93
         versionName version
         vectorDrawables.useSupportLibrary = true
     }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ConsentVisualStepLayout.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.support.v4.graphics.drawable.DrawableCompat;
+import android.text.Html;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
@@ -102,11 +103,11 @@ public class ConsentVisualStepLayout extends FixedSubmitBarLayout implements Ste
         TextView titleView = (TextView) findViewById(R.id.title);
         String title = TextUtils.isEmpty(data.getTitle()) ? getResources().getString(data.getType()
                 .getTitleResId()) : data.getTitle();
-        titleView.setText(title);
+        titleView.setText(Html.fromHtml(title));
 
         // Set Summary
         TextView summaryView = (TextView) findViewById(R.id.summary);
-        summaryView.setText(data.getSummary());
+        summaryView.setText(Html.fromHtml(data.getSummary()));
 
         // Set more info
         TextView moreInfoView = (TextView) findViewById(R.id.more_info);

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/SurveyStepLayout.java
@@ -169,7 +169,7 @@ public class SurveyStepLayout extends FixedSubmitBarLayout implements StepLayout
         if(! TextUtils.isEmpty(questionStep.getTitle()))
         {
             title.setVisibility(View.VISIBLE);
-            title.setText(questionStep.getTitle());
+            title.setText(Html.fromHtml(questionStep.getTitle()));
         }
 
         if(! TextUtils.isEmpty(questionStep.getText()))

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version = '2.0.85'
+version = '2.0.86'
 
 android {
     compileSdkVersion 25
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 92
+        versionCode 93
         versionName version
     }
     buildTypes {


### PR DESCRIPTION
### Description

Use `Html.fromHtml` for survey's and consent's steps to allow admins include some formatting

![device-2018-06-13-164026](https://user-images.githubusercontent.com/5314707/41377730-59478a84-6f33-11e8-8cdf-e42cdee419ac.png)
![device-2018-06-13-150700](https://user-images.githubusercontent.com/5314707/41377743-607c4862-6f33-11e8-8525-9816b72d5158.png)


### Acceptance Criteria

 - [ ] Check that bold and italic is supported on questions titles for surveys and summary for consent.

* Currently the surveys and consent doesn't have any HTML tag on their text, this will be included on a future update of the admin portal, this was tested addind tags manually on the Medaptive App